### PR TITLE
toggle create-geojson icon on closing of right sidebar with x

### DIFF
--- a/js/bbox.js
+++ b/js/bbox.js
@@ -429,7 +429,7 @@ $(document).ready(function() {
 
     rsidebar = L.control.sidebar('rsidebar', {
         position: 'right',
-        closeButton: false
+        closeButton: true
     });
     rsidebar.on( "sidebar-show", function(e){
         $("#map .leaflet-tile-loaded").addClass( "blurred" );
@@ -651,7 +651,11 @@ $(document).ready(function() {
     // handle create-geojson click events
     $('#create-geojson').click(function(){
         rsidebar.toggle();
-	$('#create-geojson a').toggleClass('enabled');
+        $('#create-geojson a').toggleClass('enabled');
+    });
+    // close right sidebar with leaflet's "X"
+    $('.right a.close').click(function(){
+        $('#create-geojson a').toggleClass('enabled');
     });
 
     // handle geolocation click events


### PR DESCRIPTION
Just adding back the `closeButton: true` so we can close the sidebar using Leaflet's built-in 'x' - the previous issue dealt with the `create-geojson` icon not toggling back to 'inactive' but now there's just a quick jQuery check to push it back to its normal state.

**Note:** this is _only_ for the right sidebar right now, would be good to check for any sidebar that's opened in the future.
