### PR TITLE
New Coordinates Info Box

### DIFF
--- a/css/bbox.css
+++ b/css/bbox.css
@@ -11,58 +11,66 @@ html, body, #map {
   height:auto;
   bottom:0;
   border:0 0 7px 0;
-  text-align:center;
   z-index:10000;
 }
-#info-toggle {
-  text-align:right;
+#info img {
+  vertical-align:middle;
+  height:16px;
+  width:auto;
+  opacity:0.6;
 }
-#info-toggle-button {
-  position:relative;
-  width:60px;
-  padding:4px 0;
-  left:40px;
-  background-color:#ffffff;
-  text-align:center;
+#info img:hover {
+  opacity:1;
+  cursor:pointer;
+}
+#info-toggle ul {
+  margin:0 0 0 20px;
+  padding:0;
+}
+#info-toggle ul li {
+  display:inline-block;
+  padding:4px 7px 0;
+  background-color:rgba(230,230,230,0.4);
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
   font-weight:900;
   cursor:pointer;
 }
+#info-toggle ul li.active {
+  background-color:rgba(255,255,255,0.8);
+}
+#info-toggle-button {
+  background-color:rgba(0,0,0,0.7) !important;
+  color:#fff;
+}
 #info-toggle-button:hover {
   background-color:#f4f4f4;
 }
-#info.active {
-  
-}
-#labels {
-  padding:2px 0;
-  background-color:#e1e1e1;
-  border-bottom:#c0c0c0 solid 1px;
-}
-#wgslabel {
-   margin-right:50px;
-}
 #projlabel,
 #wgslabel {
-   font-size: small;
-   font-weight:bold;
-   display:inline-block;
-   color:#333;
-   z-index: 10000;
+  display:inline-block;
+  color:#333;
+  z-index: 10000;
 }
-#coords {
+#projcoords {
+  display:none;
+}
+.coords {
+  text-align:left;
   padding:7px 0;
-  background-color:rgba(255,255,255,0.7);
+  background-color:rgba(255,255,255,0.8);
 }
 #bbounds,
 #mbounds,
-#mcenter,
-#mouse,
-#zoom {
+#mcenter {
   font-size: small;
   display:block;
   z-index:10000;
+  padding:2px 0;
+}
+#mouse, 
+#zoom {
+  display:inline-block;
 }
 .bboxlabel {
    font-size: small;
@@ -73,68 +81,24 @@ html, body, #map {
    text-align:center;
    display:inline-block;
    padding-left:2px;
-   width:40px;
-} 
-.bboxlabelbig {
-   font-size: small;
-   font-weight:bold;
-   z-index:10000;
-   background-color:black;
-   color:white;
-   text-align:center;
-   display:inline-block;
-   padding-left:2px;
    width:60px;
 } 
-.bboxllpos {
-   font-size: small;
-   font-weight:bold;
-   background-color:white;
-   color:black;
-   display:inline-block;
-   padding-left:2px;
-   width:350px;
-}
-
-.bboxllpossmall {
-   font-size: small;
-   font-weight:bold;
-   background-color:white;
-   color:black;
-   display:inline-block;
-   padding-left:2px;
-   width:200px;
-}
-
-.bboxprojpos {
-   font-size: small;
-   font-weight:bold;
-   background-color:white;
-   color:black;
-   display:inline-block;
-   padding-left:2px;
-   width:450px;
-}
-
-.bboxprojpossmall {
-   font-size: small;
-   font-weight:bold;
-   background-color:white;
-   color:black;
-   display:inline-block;
-   padding-left:2px;
-   width:250px;
-}
-
+.bboxllpos,
+.bboxllpossmall,
+.bboxprojpos,
+.bboxprojpossmall,
 .zoomsmall {
-   font-size: small;
-   font-weight:bold;
-   background-color:white;
-   color:black;
-   display:inline-block;
-   padding-left:2px;
-   width:20px;
+  font-size:small;
+  font-weight:bold;
+  color:black;
+  display:inline-block;
+  padding-left:5px;
 }
+.bboxllpos { width:350px; }
+.bboxllpossmall { width:200px; }
+.bboxprojpos { width:450px; }
+.bboxprojpossmall { width:250px; }
+.zoomsmall { width:20px; }
 
 #map-ui-proj {
     position: absolute;
@@ -255,11 +219,7 @@ html, body, #map {
 }
 
 .zeroclipboard-is-hover {
-  color: rgb(51, 51, 51);
-  background-color: rgb(230, 230, 230);
-  text-decoration: none;
-  background-position: 0px -15px;
-  transition: background-position 0.1s linear 0s;
+  opacity:1 !important;
 }
 
 .leaflet-sidebar textarea{

--- a/index.html
+++ b/index.html
@@ -45,27 +45,56 @@
 
     <section id="info-box">
         <div id="info-toggle">
-            <div id="info-toggle-button">Hide</div>
+            <ul>
+                <li id="info-toggle-button">Hide Coordinates</li>
+                <li id="wgslabel" class="active"></li>
+                <li id="projlabel"></li>
+            </ul>
         </div>
         <div id="info">
-            <div id="labels">
-                <div id="wgslabel"></div><div id="projlabel"></div>
-            </div>
-            <div id="coords">
-                <div id="bbounds">
-                    <img id="boxboundsbtn" data-clipboard-target="boxbounds" src="/images/copy.png" style="vertical-align:bottom;height:18px;"><span id="boxbounds" class="bboxllpos"></span><span id="bbboundslabel" class="bboxlabel">Box</span><span id="boxboundsmerc" class="bboxprojpos"></span><img id="boxboundsmercbtn" data-clipboard-target="boxboundsmerc" src="/images/copy.png" style="vertical-align:bottom;height:18px;">
-                </div>
-                <div id="mbounds">
-                    <img id="mapboundsbtn" data-clipboard-target="mapbounds" src="/images/copy.png" style="vertical-align:bottom;height:18px;"><span id="mapbounds" class="bboxllpos"></span><span id="mboundslabel" class="bboxlabel">Map</span><span id="mapboundsmerc" class="bboxprojpos"></span><img id="mapboundsmercbtn" data-clipboard-target="mapboundsmerc" src="/images/copy.png" style="vertical-align:bottom;height:18px;">
-                </div>
-                <div id="mcenter">
-                    <img id="centerbtn" data-clipboard-target="center" src="/images/copy.png" style="vertical-align:bottom;height:18px;"><span id="center" class="bboxllpossmall"></span><span id="mcenterlabel" class="bboxlabelbig">Center</span><span id="centermerc" class="bboxprojpossmall"></span><img id="centermercbtn" data-clipboard-target="centermerc" src="/images/copy.png" style="vertical-align:bottom;height:18px;">
-                </div>
+            <div id="wgscoords" class="coords">
                 <div id="mouse">
-                    <span id="mousepos" class="bboxllpossmall"></span><span id="mouselabel" class="bboxlabelbig">Mouse</span><span id="mouseposmerc" class="bboxprojpossmall"></span>
+                    <span id="mouselabel" class="bboxlabel">Mouse</span>
+                    <span id="mousepos" class="bboxllpossmall"></span>
                 </div>
                 <div id="zoom">
-                    <span id="bboxlabel" class="bboxlabelbig">Zoom</span><span id="zoomlevel" class="zoomsmall"></span>
+                    <span id="bboxlabel" class="bboxlabel">Zoom</span>
+                    <span class="zoomlevel zoomsmall"></span>
+                </div>
+                <div id="bbounds">
+                    <span id="bbboundslabel" class="bboxlabel">Box</span>
+                    <img id="boxboundsbtn" data-clipboard-target="boxbounds" src="/images/copy.png"><span id="boxbounds" class="bboxllpos"></span>
+                </div>
+                <div id="mbounds">
+                    <span id="mboundslabel" class="bboxlabel">Map</span>
+                    <img id="mapboundsbtn" data-clipboard-target="mapbounds" src="/images/copy.png"><span id="mapbounds" class="bboxllpos"></span>
+                </div>
+                <div id="mcenter">
+                    <span id="mcenterlabel" class="bboxlabel">Center</span>
+                    <img id="centerbtn" data-clipboard-target="center" src="/images/copy.png"><span id="center" class="bboxllpossmall"></span>
+                </div>
+                
+            </div>
+            <div id="projcoords" class="coords">
+                <div id="mouse">
+                    <span id="mouselabel" class="bboxlabel">Mouse</span>
+                    <span id="mouseposmerc" class="bboxprojpossmall"></span>
+                </div>
+                <div id="zoom">
+                    <span id="bboxlabel" class="bboxlabel">Zoom</span>
+                    <span class="zoomlevel zoomsmall"></span>
+                </div>
+                <div id="bbounds">
+                    <span id="bbboundslabel" class="bboxlabel">Box</span>
+                    <img id="boxboundsmercbtn" data-clipboard-target="boxboundsmerc" src="/images/copy.png"><span id="boxboundsmerc" class="bboxprojpos"></span>
+                </div>
+                <div id="mbounds">
+                    <span id="mboundslabel" class="bboxlabel">Map</span>
+                    <img id="mapboundsmercbtn" data-clipboard-target="mapboundsmerc" src="/images/copy.png"><span id="mapboundsmerc" class="bboxprojpos"></span>
+                </div>
+                <div id="mcenter">
+                    <span id="mcenterlabel" class="bboxlabel">Center</span>
+                    <img id="centermercbtn" data-clipboard-target="centermerc" src="/images/copy.png"><span id="centermerc" class="bboxprojpossmall"></span>
                 </div>
             </div>
         </div>

--- a/js/bbox.js
+++ b/js/bbox.js
@@ -537,7 +537,7 @@ $(document).ready(function() {
         map.fitBounds(bounds.getBounds());
     });
     
-    $('#zoomlevel').text(map.getZoom().toString());
+    $('.zoomlevel').text(map.getZoom().toString());
     $('#mapbounds').text(formatBounds(map.getBounds(),'4326','gdal'));
     $('#mapboundsmerc').text(formatBounds(map.getBounds(),currentproj,'gdal'));
     $('#center').text(formatPoint(map.getCenter(),'4326','gdal'));
@@ -560,7 +560,7 @@ $(document).ready(function() {
         $('#centermerc').text(formatPoint(map.getCenter(),currentproj,'gdal'));
     });
     map.on('zoomend', function(e) {
-        $('#zoomlevel').text(map.getZoom().toString());
+        $('.zoomlevel').text(map.getZoom().toString());
         $('#mapbounds').text(formatBounds(map.getBounds(),'4326','gdal'));
         $('#mapboundsmerc').text(formatBounds(map.getBounds(),currentproj,'gdal'));
     });
@@ -660,13 +660,29 @@ $(document).ready(function() {
 
     // toggle #info-box
     $('#info-toggle-button').click(function(){
-        $('#info').slideToggle(300);
+        $('#wgslabel, #projlabel').fadeToggle(200);
+        $('#info').delay(300).slideToggle(200);
+        
+        
         var buttonText = $('#info-toggle-button').text();
-        if (buttonText == 'Hide') {
-            $('#info-toggle-button').text('Show');
+        if (buttonText == 'Hide Coordinates') {
+            $('#info-toggle-button').text('Show Coordinates');
         } else {
-            $('#info-toggle-button').text('Hide');
+            $('#info-toggle-button').text('Hide Coordinates');
         }
+    });
+
+    // toggle coordinate tabs
+    $('#wgslabel, #projlabel').click(function(){
+        active = $(this).hasClass('active');
+        if(active){
+            //do nothing
+        } else {
+            $('#wgslabel, #projlabel').toggleClass('active');
+            $('#wgscoords, #projcoords').toggle();
+        }
+        
+        
     });
 
     // handle geolocation click events


### PR DESCRIPTION
I did a little cleaning to the coordinate systems UI so reading the information is simpler and more straightforward. You'll notice a couple major things:
- The entire information box can be 'hidden' to give the user more room (uses jQuery `.slideToggle()`)
- The two different reference systems (coordinate systems) are now each in their own individual tab sections (toggled using jQuery's `.toggle()`) to give the user a little more visual discrimination between the number sets. One loss in UI here: the user now cannot see the numbers side-by-side, but IMO seeing the numbers separately and symmetrically is more beneficial since the user can distinctly learn about each system in their own space.

That's the gist of it. Hope you like it! Give me a holler if something looks off or if it should be updated further. Thanks, @aaronr!
