### PR TITLE
Move OSM/etc attributions to top right

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 
 </head>
 <body>
-    <a href="https://github.com/cugos/bboxfinder.com"><img style="position: absolute; top: 5; right: 5; border: 0; z-index:3000; max-height:30px; max-width:30px;" src="images/octocat.png" alt="Fork me on GitHub"></a>
+    <a href="https://github.com/cugos/bboxfinder.com"><img style="position: absolute; top: 20; right: 5; border: 0; z-index:3000; max-height:30px; max-width:30px;" src="images/octocat.png" alt="Fork me on GitHub"></a>
     <ul id="map-ui-proj">
         <li><label class="epsglabel" id="projection_label" for="projection" title="EPSG projection code">EPSG: </label><input id="projection" size="6"/></li>
     </ul>

--- a/js/bbox.js
+++ b/js/bbox.js
@@ -471,6 +471,8 @@ $(document).ready(function() {
         pixelRatio: window.devicePixelRatio || 1
     }).addTo(map);
 
+    map.attributionControl.setPosition('topright');
+
     rsidebar = L.control.sidebar('rsidebar', {
         position: 'right',
         closeButton: true


### PR DESCRIPTION
Resolves issue #45 

Previously the Leaflet attribution pane was in the lower right, under our main menu. Even when the menu was hidden, the attribution links were not clickable: 

<img width="1439" height="739" alt="Screenshot 2026-04-12 at 10 08 16 AM" src="https://github.com/user-attachments/assets/23ed8db0-d5f1-4b1a-befa-de574ba043f2" />
<img width="1439" height="739" alt="Screenshot 2026-04-12 at 10 08 37 AM" src="https://github.com/user-attachments/assets/eb5a87f0-c663-4703-956f-39a497e65a00" />

Now the attribution is moved to the upper right, and the Github logo is moved down a bit to make room: 

<img width="1438" height="740" alt="Screenshot 2026-04-12 at 10 08 58 AM" src="https://github.com/user-attachments/assets/f5e1f522-a5d3-4b4d-8819-3a0e032a20c9" />
